### PR TITLE
supporting gz input files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,8 @@ AC_PROG_RANLIB
 
 # Checks for header files.
 AC_CHECK_HEADERS([stdint.h])
+AC_CHECK_HEADERS([zlib.h])
+AC_SEARCH_LIBS(deflate, z)
 
 # Checks for typedefs, structures, and compiler characteristics.
 #AC_CHECK_HEADER_STDBOOL

--- a/gtfmerge/config.cc
+++ b/gtfmerge/config.cc
@@ -11,6 +11,7 @@ using namespace std;
 double min_transcript_coverage = -1;
 bool merge_coverage_as_counts = false;
 bool counts_and_coverage = false;
+bool print_samples = false;
 int num_threads = 1;
 
 int parse_parameters(int argc, const char ** argv)
@@ -35,6 +36,10 @@ int parse_parameters(int argc, const char ** argv)
 		{
 			counts_and_coverage = true;
 		}
+		else if(string(argv[i]) == "-w")
+		{
+			print_samples = true;
+		}
 	}
 
 	// not compatible with each other
@@ -55,5 +60,6 @@ int print_help()
 	printf(" %-14s  %s\n", "-t <integer>",  "number of threads");
 	printf(" %-14s  %s\n", "-n",  "only output number of transcript occurrences");
 	printf(" %-14s  %s\n", "-b",  "output total coverage sum as well as occurrences. Not compatible with -n");
+	printf(" %-14s  %s\n", "-w",  "write samples containing each transcript to <output-unioned-gtf>.samples.txt");
 	return 0;
 }

--- a/gtfmerge/config.h
+++ b/gtfmerge/config.h
@@ -10,6 +10,7 @@ using namespace std;
 extern double min_transcript_coverage;
 extern bool merge_coverage_as_counts;
 extern bool counts_and_coverage;
+extern bool print_samples;
 extern int num_threads;
 
 int parse_parameters(int argc, const char ** argv);

--- a/gtfmerge/genome1.cc
+++ b/gtfmerge/genome1.cc
@@ -23,6 +23,7 @@ int genome1::build(const string &file)
 			transcript t = g.transcripts[k];
 			if(t.exons.size() <= 1) continue;
 			t.occurrence = 1.0;
+			t.samples = file;
 			add_transcript(t);
 		}
 	}
@@ -61,6 +62,8 @@ int genome1::add_transcript(const transcript &t)
 		transcript* tt = &transcripts[k];
 
 		tt->occurrence += t.occurrence;
+		tt->samples += ",";
+		tt->samples += t.samples;
 
 		double tt_rc = tt->coverage * tt->length();
 		double t_rc = t.coverage * t.length();
@@ -136,12 +139,27 @@ int genome1::print_hashing()
 int genome1::write(const string &file)
 {
 	ofstream fout(file.c_str());
-	if(fout.fail()) return 0;
+	if(fout.fail()) return 1;
 	for(int i = 0; i < transcripts.size(); i++)
 	{
 		transcript &t = transcripts[i];
 		if(t.coverage < min_transcript_coverage) continue;
 		t.write(fout, (counts_and_coverage || merge_coverage_as_counts), (counts_and_coverage || !merge_coverage_as_counts));
+	}
+	fout.close();
+	return 0;
+}
+
+int genome1::write_samples(const string &file)
+{
+	string samples_file = file + ".samples.txt";
+	ofstream fout(samples_file);
+	if(fout.fail()) return 1;
+	for(int i = 0; i < transcripts.size(); i++)
+	{
+		transcript &t = transcripts[i];
+		if(t.coverage < min_transcript_coverage) continue;
+		fout << t.gene_id << "\t" << t.samples << endl;
 	}
 	fout.close();
 	return 0;

--- a/gtfmerge/genome1.cc
+++ b/gtfmerge/genome1.cc
@@ -159,7 +159,7 @@ int genome1::write_samples(const string &file)
 	{
 		transcript &t = transcripts[i];
 		if(t.coverage < min_transcript_coverage) continue;
-		fout << t.gene_id << "\t" << t.samples << endl;
+		fout << t.gene_id << "\t" << t.samples << "\n";
 	}
 	fout.close();
 	return 0;

--- a/gtfmerge/genome1.h
+++ b/gtfmerge/genome1.h
@@ -26,6 +26,7 @@ public:
 	int build_intersection(const genome1 &gm, genome1 &out);
 	int clear();
 	int write(const string &file);
+	int write_samples(const string &file);
 	int add_suffix(const string &p);
 	int remove_redundancy();
 	int print(int index);

--- a/gtfmerge/main.cc
+++ b/gtfmerge/main.cc
@@ -27,6 +27,8 @@ int main(int argc, const char **argv)
 		gtfmerge gm;
 		gm.build_union(argv[2]);
 		gm.gm.write(argv[3]);
+		if (print_samples)
+			gm.gm.write_samples(argv[3]);
 	}
 
     return 0;

--- a/lib/gtf/Makefile.am
+++ b/lib/gtf/Makefile.am
@@ -7,4 +7,5 @@ libgtf_a_CPPFLAGS = -I$(UTILDIR)
 libgtf_a_SOURCES = item.h item.cc \
 				   transcript.h transcript.cc \
 				   gene.h gene.cc \
+				   gz_reader.h gz_reader.cc \
 				   genome.h genome.cc

--- a/lib/gtf/genome.cc
+++ b/lib/gtf/genome.cc
@@ -76,48 +76,48 @@ int genome::read_gz(const string &file)
 	return 0;
 }
 
-// int genome::read(const string &file)
-// {
-// 	if(file == "") return 0;
+int genome::read(const string &file)
+{
+	if(file == "") return 0;
 
-// 	ifstream fin(file.c_str());
-// 	if(fin.fail())
-// 	{
-// 		printf("open file %s error\n", file.c_str());
-// 		return 0;
-// 	}
+	ifstream fin(file.c_str());
+	if(fin.fail())
+	{
+		printf("open file %s error\n", file.c_str());
+		return 0;
+	}
 
-// 	char line[102400];
+	char line[102400];
 	
-// 	genes.clear();
-// 	g2i.clear();
-// 	while(fin.getline(line, 102400, '\n'))
-// 	{
-// 		item ge(line);
-// 		if(g2i.find(ge.gene_id) == g2i.end())
-// 		{
-// 			gene gg;
-// 			if(ge.feature == "transcript") gg.add_transcript(ge);
-// 			else if(ge.feature == "exon") gg.add_exon(ge);
-// 			g2i.insert(pair<string, int>(ge.gene_id, genes.size()));
-// 			genes.push_back(gg);
-// 		}
-// 		else
-// 		{
-// 			int k = g2i[ge.gene_id];
-// 			if(ge.feature == "transcript") genes[k].add_transcript(ge);
-// 			else if(ge.feature == "exon") genes[k].add_exon(ge);
-// 		}
-// 	}
+	genes.clear();
+	g2i.clear();
+	while(fin.getline(line, 102400, '\n'))
+	{
+		item ge(line);
+		if(g2i.find(ge.gene_id) == g2i.end())
+		{
+			gene gg;
+			if(ge.feature == "transcript") gg.add_transcript(ge);
+			else if(ge.feature == "exon") gg.add_exon(ge);
+			g2i.insert(pair<string, int>(ge.gene_id, genes.size()));
+			genes.push_back(gg);
+		}
+		else
+		{
+			int k = g2i[ge.gene_id];
+			if(ge.feature == "transcript") genes[k].add_transcript(ge);
+			else if(ge.feature == "exon") genes[k].add_exon(ge);
+		}
+	}
 
-// 	for(int i = 0; i < genes.size(); i++)
-// 	{
-// 		genes[i].sort();
-// 		genes[i].shrink();
-// 	}
+	for(int i = 0; i < genes.size(); i++)
+	{
+		genes[i].sort();
+		genes[i].shrink();
+	}
 
-// 	return 0;
-// }
+	return 0;
+}
 
 int genome::write(const string &file) const
 {

--- a/lib/gtf/genome.cc
+++ b/lib/gtf/genome.cc
@@ -11,13 +11,15 @@ See LICENSE for licensing.
 
 #include "genome.h"
 #include "util.h"
+#include "gz_reader.h"
 
 genome::genome()
 {}
 
 genome::genome(const string &file)
 {
-	read(file);
+	read_gz(file);
+	// read(file);
 }
 
 genome::~genome()
@@ -33,22 +35,18 @@ int genome::add_gene(const gene &g)
 	return 0;
 }
 
-int genome::read(const string &file)
+int genome::read_gz(const string &file)
 {
-	if(file == "") return 0;
-
-	ifstream fin(file.c_str());
-	if(fin.fail())
-	{
-		printf("open file %s error\n", file.c_str());
-		return 0;
-	}
+	gz_reader gzrd;
+	if (gzrd.open_gz(file) != 0) {
+        return 0;
+    }
 
 	char line[102400];
 	
 	genes.clear();
 	g2i.clear();
-	while(fin.getline(line, 102400, '\n'))
+	while(gzrd.getline(line, 102400, '\n'))
 	{
 		item ge(line);
 		if(g2i.find(ge.gene_id) == g2i.end())
@@ -73,8 +71,53 @@ int genome::read(const string &file)
 		genes[i].shrink();
 	}
 
+	gzrd.close_gz();
+
 	return 0;
 }
+
+// int genome::read(const string &file)
+// {
+// 	if(file == "") return 0;
+
+// 	ifstream fin(file.c_str());
+// 	if(fin.fail())
+// 	{
+// 		printf("open file %s error\n", file.c_str());
+// 		return 0;
+// 	}
+
+// 	char line[102400];
+	
+// 	genes.clear();
+// 	g2i.clear();
+// 	while(fin.getline(line, 102400, '\n'))
+// 	{
+// 		item ge(line);
+// 		if(g2i.find(ge.gene_id) == g2i.end())
+// 		{
+// 			gene gg;
+// 			if(ge.feature == "transcript") gg.add_transcript(ge);
+// 			else if(ge.feature == "exon") gg.add_exon(ge);
+// 			g2i.insert(pair<string, int>(ge.gene_id, genes.size()));
+// 			genes.push_back(gg);
+// 		}
+// 		else
+// 		{
+// 			int k = g2i[ge.gene_id];
+// 			if(ge.feature == "transcript") genes[k].add_transcript(ge);
+// 			else if(ge.feature == "exon") genes[k].add_exon(ge);
+// 		}
+// 	}
+
+// 	for(int i = 0; i < genes.size(); i++)
+// 	{
+// 		genes[i].sort();
+// 		genes[i].shrink();
+// 	}
+
+// 	return 0;
+// }
 
 int genome::write(const string &file) const
 {

--- a/lib/gtf/genome.cc
+++ b/lib/gtf/genome.cc
@@ -13,6 +13,8 @@ See LICENSE for licensing.
 #include "util.h"
 #include "gz_reader.h"
 
+#define MAX_LINE_SIZE 102400
+
 genome::genome()
 {}
 
@@ -42,11 +44,11 @@ int genome::read_gz(const string &file)
         return 0;
     }
 
-	char line[102400];
+	char line[MAX_LINE_SIZE];
 	
 	genes.clear();
 	g2i.clear();
-	while(gzrd.getline(line, 102400, '\n'))
+	while(gzrd.getline(line, sizeof(line), '\n'))
 	{
 		item ge(line);
 		if(g2i.find(ge.gene_id) == g2i.end())
@@ -87,11 +89,11 @@ int genome::read(const string &file)
 		return 0;
 	}
 
-	char line[102400];
+	char line[MAX_LINE_SIZE];
 	
 	genes.clear();
 	g2i.clear();
-	while(fin.getline(line, 102400, '\n'))
+	while(fin.getline(line, sizeof(line), '\n'))
 	{
 		item ge(line);
 		if(g2i.find(ge.gene_id) == g2i.end())

--- a/lib/gtf/genome.h
+++ b/lib/gtf/genome.h
@@ -9,6 +9,7 @@ See LICENSE for licensing.
 
 #include <string>
 #include <map>
+#include <zlib.h>
 #include "gene.h"
 
 using namespace std;
@@ -27,6 +28,7 @@ public:
 public:
 	// read and write
 	int read(const string &file);
+	int read_gz(const string &file);
 	int write(const string &file) const;
 
 	// modify

--- a/lib/gtf/gz_reader.cc
+++ b/lib/gtf/gz_reader.cc
@@ -1,0 +1,75 @@
+/*
+Author: Hossein Asghari
+*/
+
+#include <string>
+#include <zlib.h>
+#include "gz_reader.h"
+
+gz_reader::gz_reader()
+{
+    gzinput = Z_NULL;
+    zbuffer = (char *) malloc(BUFFSIZE);
+
+    buff_pos = 0;
+    buff_size = 0;
+}
+
+gz_reader::~gz_reader() 
+{
+    free(zbuffer);
+}
+
+int gz_reader::open_gz(const string &file) 
+{
+    gzinput = gzopen(file.c_str(), "r");
+    
+    if (gzinput == Z_NULL) {
+        printf("Error: Could not open gzip file %s\n", file.c_str());
+        return 1;
+    }
+
+    return 0;
+}
+
+void gz_reader::close_gz() 
+{
+    if (gzinput != Z_NULL) {
+        gzclose(gzinput);
+    }
+}
+
+void gz_reader::read_buffer(uint32_t size) {
+    buff_size = gzread(gzinput, zbuffer, size);
+    buff_pos = 0;
+
+    if (buff_size == 0 and gzeof(gzinput) == 0) {
+        buff_size = -1;
+    }
+    if (buff_size < 0) {
+        int err;
+        fprintf(stderr, "gzread error: %s\n", gzerror(gzinput, &err));
+        exit(1);
+    }
+}
+
+uint32_t gz_reader::getline(char *line, uint32_t size, char delim) {
+    char cur;
+
+    uint32_t i = 0;
+    while (true) {
+        if (buff_pos >= buff_size) {
+            read_buffer(size);
+            if (buff_size == 0)
+                return 0;
+        }
+
+        cur = zbuffer[buff_pos++];
+        if (cur == delim) {
+            line[i] = '\0';
+            return i;
+        }
+
+        line[i++] = cur;
+    }
+}

--- a/lib/gtf/gz_reader.h
+++ b/lib/gtf/gz_reader.h
@@ -1,0 +1,34 @@
+/*
+Author: Hossein Asghari
+*/
+
+#ifndef __GZ_READER_FILE_H__
+#define __GZ_READER_FILE_H__
+
+#include <string>
+#include <zlib.h>
+
+#define BUFFSIZE 10000000
+
+using namespace std;
+
+class gz_reader {
+private:
+    gzFile gzinput;
+    char *zbuffer;
+    int32_t buff_pos;
+    int32_t buff_size;
+
+    void read_buffer(uint32_t size);
+
+public:
+    gz_reader();
+    ~gz_reader();
+
+    int open_gz(const string &file);
+    void close_gz();
+    
+    uint32_t getline(char *line, uint32_t size, char delim);
+};
+
+#endif

--- a/lib/gtf/item.cc
+++ b/lib/gtf/item.cc
@@ -38,6 +38,8 @@ int item::parse(const string &s)
 	sstr>>buf;
 	frame = buf[0];
 
+	samples = "";
+
 	char buf2[10240];
 	coverage = 0;
 	occurrence = 0;

--- a/lib/gtf/item.h
+++ b/lib/gtf/item.h
@@ -31,6 +31,7 @@ public:
 	string transcript_id;
 	string transcript_type;
 	string gene_type;
+	string samples;
 	int32_t start;
 	int32_t end;
 	double score;

--- a/lib/gtf/transcript.cc
+++ b/lib/gtf/transcript.cc
@@ -35,6 +35,7 @@ int transcript::assign(const item &e)
 	gene_id = e.gene_id;
 	transcript_id = e.transcript_id;
 	transcript_type = e.transcript_type;
+	samples = e.samples;
 	gene_type = e.gene_type;
 	start = e.start;
 	end = e.end;
@@ -69,6 +70,7 @@ int transcript::clear()
 	transcript_id = "";
 	transcript_type = "";
 	gene_type = "";
+	samples = "";
 	start = 0;
 	end = 0;
 	strand = '.';

--- a/lib/gtf/transcript.cc
+++ b/lib/gtf/transcript.cc
@@ -253,7 +253,7 @@ int transcript::write(ostream &fout, bool write_occ, bool write_cov) const
 		fout<<"occ \""<<occurrence<<"\"; ";
 	if (write_cov)
 		fout<<"cov \""<<coverage<<"\";";
-	fout<<endl;
+	fout<<"\n";
 
 	for(int k = 0; k < exons.size(); k++)
 	{
@@ -267,7 +267,7 @@ int transcript::write(ostream &fout, bool write_occ, bool write_cov) const
 		fout<<".\t";						// frame
 		fout<<"gene_id \""<<gene_id<<"\"; ";
 		fout<<"transcript_id \""<<transcript_id<<"\"; ";
-		fout<<"exon \""<<k + 1<<"\"; "<<endl;
+		fout<<"exon \""<<k + 1<<"\"; "<<"\n";
 	}
 	return 0;
 }
@@ -294,7 +294,7 @@ int transcript::write(ostream &fout) const
 	if(gene_type != "") fout<<"gene_type \""<<gene_type.c_str()<<"\"; ";
 	if(transcript_type != "") fout<<"transcript_type \""<<transcript_type.c_str()<<"\"; ";
 	fout<<"RPKM \""<<RPKM<<"\"; ";
-	fout<<"cov \""<<coverage<<"\";"<<endl;
+	fout<<"cov \""<<coverage<<"\";"<<"\n";
 
 	for(int k = 0; k < exons.size(); k++)
 	{
@@ -308,7 +308,7 @@ int transcript::write(ostream &fout) const
 		fout<<".\t";						// frame
 		fout<<"gene_id \""<<gene_id.c_str()<<"\"; ";
 		fout<<"transcript_id \""<<transcript_id.c_str()<<"\"; ";
-		fout<<"exon \""<<k + 1<<"\"; "<<endl;
+		fout<<"exon \""<<k + 1<<"\"; "<<"\n";
 	}
 	return 0;
 }

--- a/lib/gtf/transcript.h
+++ b/lib/gtf/transcript.h
@@ -35,6 +35,7 @@ public:
 	string transcript_id;
 	string gene_type;
 	string transcript_type;
+	string samples;
 	int32_t start;
 	int32_t end;
 	double score;


### PR DESCRIPTION
All of the rnaseqtools are now able to accept compressed (gzipped) gtf files or a combination of compressed and uncompressed files (for example for gtfmerge).

I have tested it specifically on gtfcuff and gtfmerge and they generate the same output while reading a gz gtf file but more testing is appreciated if you have time. 